### PR TITLE
fix: prefer glibc microsocks build and restart services on reconfig

### DIFF
--- a/internal/tunnel/dnstt/provider.go
+++ b/internal/tunnel/dnstt/provider.go
@@ -190,7 +190,8 @@ func (p *Provider) performInstallation(cfg *Config) (*tunnel.InstallResult, erro
 		return nil, fmt.Errorf("failed to enable service: %w", err)
 	}
 
-	if err := Start(); err != nil {
+	// Use Restart instead of Start to apply config changes if service is already running
+	if err := Restart(); err != nil {
 		return nil, fmt.Errorf("failed to start service: %w", err)
 	}
 	tui.PrintStatus("Service started")

--- a/internal/tunnel/shadowsocks/provider.go
+++ b/internal/tunnel/shadowsocks/provider.go
@@ -220,7 +220,8 @@ func (p *Provider) performInstallation(cfg *Config) (*tunnel.InstallResult, erro
 		return nil, fmt.Errorf("failed to enable service: %w", err)
 	}
 
-	if err := Start(); err != nil {
+	// Use Restart instead of Start to apply config changes if service is already running
+	if err := Restart(); err != nil {
 		return nil, fmt.Errorf("failed to start service: %w", err)
 	}
 	tui.PrintStatus("Service started")

--- a/internal/tunnel/slipstream/provider.go
+++ b/internal/tunnel/slipstream/provider.go
@@ -186,7 +186,8 @@ func (p *Provider) performInstallation(cfg *Config) (*tunnel.InstallResult, erro
 		return nil, fmt.Errorf("failed to enable service: %w", err)
 	}
 
-	if err := Start(); err != nil {
+	// Use Restart instead of Start to apply config changes if service is already running
+	if err := Restart(); err != nil {
 		return nil, fmt.Errorf("failed to start service: %w", err)
 	}
 	tui.PrintStatus("Service started")


### PR DESCRIPTION
## Summary

- Prefer GNU/glibc microsocks builds over musl on standard Linux distributions
- Fix service restart after provider reconfiguration

## Changes

**microsocks glibc detection:**
- Add `detectLibc()` to detect glibc vs musl systems
- Prefer `microsocks-x86_64-linux-gnu` on Debian/Ubuntu/RHEL etc.
- Fall back to musl builds for Alpine or unsupported architectures
- Fixes HTTPS/TLS traffic crashes with musl builds

**Service restart fix:**
- Use `Restart()` instead of `Start()` after provider installation
- Ensures config changes are applied when reconfiguring existing providers

## Test plan

- [x] Tested microsocks glibc build with HTTPS traffic through DNS tunnel
- [x] Verified service restart applies config changes on mode switch