### PR TITLE
feat: add separators and external tools section to main menu

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/net2share/dnstm
 go 1.24.0
 
 require (
-	github.com/net2share/go-corelib v0.1.7
+	github.com/net2share/go-corelib v0.1.8
 	github.com/spf13/cobra v1.10.2
 	github.com/ulikunitz/xz v0.5.15
 	golang.org/x/crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/net2share/go-corelib v0.1.7 h1:dzFqSD6UCdTaDehhn0+BMpDNK3AhxNQ4AFxc1jCBYag=
 github.com/net2share/go-corelib v0.1.7/go.mod h1:aAR+jZYpIx28EKB/LAQRIaPazHMm+/E+N1JTr8div2M=
+github.com/net2share/go-corelib v0.1.8 h1:YND+F0RbGCRC/Upcg9SqND1EGDDhLGzlC5q4IQRI8fw=
+github.com/net2share/go-corelib v0.1.8/go.mod h1:aAR+jZYpIx28EKB/LAQRIaPazHMm+/E+N1JTr8div2M=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/menu/main.go
+++ b/internal/menu/main.go
@@ -223,9 +223,12 @@ func runMainMenu() error {
 			options = append(options, tui.MenuOption{Label: "Tunnels →", Value: actions.ActionTunnel})
 			options = append(options, tui.MenuOption{Label: "Backends →", Value: actions.ActionBackend})
 			options = append(options, tui.MenuOption{Label: "Router →", Value: actions.ActionRouter})
-			options = append(options, tui.MenuOption{Label: "SSH Users →", Value: actions.ActionSSHUsers})
 			options = append(options, tui.MenuOption{Label: "Update", Value: actions.ActionUpdate})
 			options = append(options, tui.MenuOption{Label: "Uninstall", Value: actions.ActionUninstall})
+			options = append(options, tui.MenuOption{Label: "", Separator: true})
+			options = append(options, tui.MenuOption{Label: "External Tools", Separator: true})
+			options = append(options, tui.MenuOption{Label: "SSH Users ↗", Value: actions.ActionSSHUsers})
+			options = append(options, tui.MenuOption{Label: "", Separator: true})
 			options = append(options, tui.MenuOption{Label: "Exit", Value: "exit"})
 		}
 


### PR DESCRIPTION
## Summary
- Add visual separators to TUI menu (divider lines and subtitle headers) via go-corelib v0.1.8
- Reorganize main menu to separate external tools (SSH Users) from built-in commands
- Cursor navigation skips non-selectable separator items