### PR TITLE
refactor: merge tunnel enable/disable into start/stop

### DIFF
--- a/internal/actions/ids.go
+++ b/internal/actions/ids.go
@@ -15,8 +15,6 @@ const (
 	ActionTunnelList        = "tunnel.list"
 	ActionTunnelAdd         = "tunnel.add"
 	ActionTunnelRemove      = "tunnel.remove"
-	ActionTunnelEnable      = "tunnel.enable"
-	ActionTunnelDisable     = "tunnel.disable"
 	ActionTunnelStart       = "tunnel.start"
 	ActionTunnelStop        = "tunnel.stop"
 	ActionTunnelRestart     = "tunnel.restart"

--- a/internal/actions/tunnel.go
+++ b/internal/actions/tunnel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/net2share/dnstm/internal/config"
+	"github.com/net2share/dnstm/internal/router"
 	"github.com/net2share/go-corelib/tui"
 )
 
@@ -81,9 +82,9 @@ func init() {
 		ID:                ActionTunnelStart,
 		Parent:            ActionTunnel,
 		Use:               "start",
-		Short:             "Start a tunnel",
-		Long:              "Start or restart a tunnel. If already running, restarts to pick up changes.",
-		MenuLabel:         "Start/Restart",
+		Short:             "Start a tunnel (enables and starts)",
+		Long:              "Enable and start a tunnel. If already running, restarts to pick up changes.",
+		MenuLabel:         "Start",
 		RequiresRoot:      true,
 		RequiresInstalled: true,
 		Args: &ArgsSpec{
@@ -99,8 +100,8 @@ func init() {
 		ID:                ActionTunnelStop,
 		Parent:            ActionTunnel,
 		Use:               "stop",
-		Short:             "Stop a tunnel",
-		Long:              "Stop a tunnel",
+		Short:             "Stop a tunnel (stops and disables)",
+		Long:              "Stop and disable a tunnel",
 		MenuLabel:         "Stop",
 		RequiresRoot:      true,
 		RequiresInstalled: true,
@@ -120,42 +121,6 @@ func init() {
 		Short:             "Restart a tunnel",
 		Long:              "Restart a tunnel",
 		MenuLabel:         "Restart",
-		RequiresRoot:      true,
-		RequiresInstalled: true,
-		Args: &ArgsSpec{
-			Name:        "tag",
-			Description: "Tunnel tag",
-			Required:    true,
-			PickerFunc:  TunnelPicker,
-		},
-	})
-
-	// Register tunnel.enable action
-	Register(&Action{
-		ID:                ActionTunnelEnable,
-		Parent:            ActionTunnel,
-		Use:               "enable",
-		Short:             "Enable a tunnel",
-		Long:              "Enable a tunnel (auto-starts in multi mode)",
-		MenuLabel:         "Enable",
-		RequiresRoot:      true,
-		RequiresInstalled: true,
-		Args: &ArgsSpec{
-			Name:        "tag",
-			Description: "Tunnel tag",
-			Required:    true,
-			PickerFunc:  TunnelPicker,
-		},
-	})
-
-	// Register tunnel.disable action
-	Register(&Action{
-		ID:                ActionTunnelDisable,
-		Parent:            ActionTunnel,
-		Use:               "disable",
-		Short:             "Disable a tunnel",
-		Long:              "Disable a tunnel (stops it in multi mode)",
-		MenuLabel:         "Disable",
 		RequiresRoot:      true,
 		RequiresInstalled: true,
 		Args: &ArgsSpec{
@@ -299,7 +264,7 @@ func TunnelPicker(ctx *Context) (string, error) {
 	var options []SelectOption
 	for _, t := range cfg.Tunnels {
 		status := SymbolStopped
-		if t.IsEnabled() {
+		if router.NewTunnel(&t).IsActive() {
 			status = SymbolRunning
 		}
 		transportName := config.GetTransportTypeDisplayName(t.Transport)

--- a/internal/handlers/backend_status.go
+++ b/internal/handlers/backend_status.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/net2share/dnstm/internal/actions"
 	"github.com/net2share/dnstm/internal/config"
+	"github.com/net2share/dnstm/internal/router"
 )
 
 func init() {
@@ -68,9 +69,9 @@ func HandleBackendStatus(ctx *actions.Context) error {
 		tunnelSection.Rows = []actions.InfoRow{{Value: "None"}}
 	} else {
 		for _, t := range tunnelsUsing {
-			status := "disabled"
-			if t.IsEnabled() {
-				status = "enabled"
+			status := "stopped"
+			if router.NewTunnel(t).IsActive() {
+				status = "running"
 			}
 			tunnelSection.Rows = append(tunnelSection.Rows, actions.InfoRow{
 				Value: fmt.Sprintf("• %s (%s, %s)", t.Tag, t.Domain, status),
@@ -106,9 +107,9 @@ func HandleBackendStatus(ctx *actions.Context) error {
 	} else {
 		ctx.Output.Printf("Tunnels using this backend (%d):\n", len(tunnelsUsing))
 		for _, t := range tunnelsUsing {
-			status := "disabled"
-			if t.IsEnabled() {
-				status = "enabled"
+			status := "stopped"
+			if router.NewTunnel(t).IsActive() {
+				status = "running"
 			}
 			ctx.Output.Printf("  - %s (%s, %s)\n", t.Tag, t.Domain, status)
 		}

--- a/internal/handlers/config_validate.go
+++ b/internal/handlers/config_validate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/net2share/dnstm/internal/actions"
 	"github.com/net2share/dnstm/internal/config"
+	"github.com/net2share/dnstm/internal/router"
 )
 
 func init() {
@@ -77,11 +78,11 @@ func HandleConfigValidate(ctx *actions.Context) error {
 		ctx.Output.Info("Tunnels:")
 		for _, t := range cfg.Tunnels {
 			transportName := config.GetTransportTypeDisplayName(t.Transport)
-			enabled := "enabled"
-			if !t.IsEnabled() {
-				enabled = "disabled"
+			status := "stopped"
+			if router.NewTunnel(&t).IsActive() {
+				status = "running"
 			}
-			ctx.Output.Printf("  - %s (%s → %s, %s)\n", t.Tag, transportName, t.Backend, enabled)
+			ctx.Output.Printf("  - %s (%s → %s, %s)\n", t.Tag, transportName, t.Backend, status)
 		}
 	}
 

--- a/internal/handlers/tunnel_add.go
+++ b/internal/handlers/tunnel_add.go
@@ -377,6 +377,8 @@ func createTunnel(ctx *actions.Context, tunnelCfg *config.TunnelConfig, cfg *con
 	// Step 6: Save config
 	currentStep++
 	ctx.Output.Step(currentStep, totalSteps, "Saving configuration...")
+	enabled := true
+	tunnelCfg.Enabled = &enabled
 	cfg.Tunnels = append(cfg.Tunnels, *tunnelCfg)
 
 	// Handle mode-specific config

--- a/internal/handlers/tunnel_list.go
+++ b/internal/handlers/tunnel_list.go
@@ -46,15 +46,9 @@ func HandleTunnelList(ctx *actions.Context) error {
 			marker = " (default)"
 		}
 
-		// Show enabled/disabled status
-		enabledMarker := ""
-		if !t.IsEnabled() {
-			enabledMarker = " [disabled]"
-		}
-
 		transportName := config.GetTransportTypeDisplayName(t.Transport)
-		ctx.Output.Printf("%-16s %-12s %-16s %-8d %-20s %s%s%s\n",
-			t.Tag, transportName, t.Backend, t.Port, t.Domain, status, marker, enabledMarker)
+		ctx.Output.Printf("%-16s %-12s %-16s %-8d %-20s %s%s\n",
+			t.Tag, transportName, t.Backend, t.Port, t.Domain, status, marker)
 	}
 
 	if cfg.IsSingleMode() {

--- a/internal/handlers/tunnel_status.go
+++ b/internal/handlers/tunnel_status.go
@@ -39,10 +39,6 @@ func HandleTunnelStatus(ctx *actions.Context) error {
 	}
 
 	// Main info section
-	enabledStr := "No"
-	if tunnelCfg.IsEnabled() {
-		enabledStr = "Yes"
-	}
 	mainSection := actions.InfoSection{
 		Rows: []actions.InfoRow{
 			{Key: "Transport", Value: config.GetTransportTypeDisplayName(tunnelCfg.Transport)},
@@ -51,7 +47,6 @@ func HandleTunnelStatus(ctx *actions.Context) error {
 			{Key: "Port", Value: fmt.Sprintf("%d", tunnelCfg.Port)},
 			{Key: "Service", Value: tunnel.ServiceName},
 			{Key: "Status", Value: tunnel.StatusString()},
-			{Key: "Enabled", Value: enabledStr},
 		},
 	}
 	infoCfg.Sections = append(infoCfg.Sections, mainSection)
@@ -110,13 +105,6 @@ func HandleTunnelStatus(ctx *actions.Context) error {
 	// CLI mode - print to console
 	ctx.Output.Println()
 	ctx.Output.Println(tunnel.GetFormattedInfo())
-
-	if tunnelCfg.IsEnabled() {
-		ctx.Output.Printf("Enabled:   Yes\n")
-	} else {
-		ctx.Output.Printf("Enabled:   No\n")
-	}
-	ctx.Output.Println()
 
 	if tunnelCfg.Transport == config.TransportSlipstream {
 		certMgr := certs.NewManager()

--- a/internal/menu/adapter.go
+++ b/internal/menu/adapter.go
@@ -23,7 +23,6 @@ func isInfoViewAction(actionID string) bool {
 		actions.ActionRouterMode,
 		actions.ActionTunnelAdd, actions.ActionTunnelRemove,
 		actions.ActionTunnelStart, actions.ActionTunnelStop, actions.ActionTunnelRestart,
-		actions.ActionTunnelEnable, actions.ActionTunnelDisable,
 		actions.ActionBackendRemove,
 		actions.ActionInstall, actions.ActionUninstall:
 		return true

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -270,13 +270,9 @@ func (r *Router) RemoveTunnel(tag string) error {
 
 	// Handle mode-specific cleanup
 	if r.config.IsSingleMode() {
-		// Update active tunnel if needed
+		// Clear active if removing the active tunnel
 		if r.config.Route.Active == tag {
 			r.config.Route.Active = ""
-			// Set to first available tunnel
-			if len(r.config.Tunnels) > 0 {
-				r.config.Route.Active = r.config.Tunnels[0].Tag
-			}
 		}
 	} else {
 		// Update default route if needed

--- a/tests/e2e/multi_test.go
+++ b/tests/e2e/multi_test.go
@@ -135,7 +135,7 @@ func TestMultiTunnel_Configuration(t *testing.T) {
 	t.Log("Multi-tunnel configuration validated successfully")
 }
 
-func TestMultiTunnel_EnableDisable(t *testing.T) {
+func TestMultiTunnel_EnabledState(t *testing.T) {
 	enabled := true
 	disabled := false
 

--- a/tests/integration/tunnel_test.go
+++ b/tests/integration/tunnel_test.go
@@ -173,7 +173,7 @@ func TestTunnelList(t *testing.T) {
 	}
 }
 
-func TestTunnelEnableDisable(t *testing.T) {
+func TestTunnelEnabledState(t *testing.T) {
 	env := NewTestEnv(t)
 
 	cfg := env.DefaultConfig()


### PR DESCRIPTION
## Summary

- Removes `tunnel enable` and `tunnel disable` commands entirely
- `start` now enables (config + systemd) before starting; `stop` disables after stopping
- Tunnel menu shows context-aware options based on running state (Start when stopped, Restart/Stop when running)
- DNS router config is regenerated on start/stop in multi mode
- Mode switch and active tunnel switch properly manage enabled state
- Warnings shown when stopping/removing the active tunnel in single mode
- Active tunnel is no longer auto-switched on removal — left empty for explicit user action
- Status views show running/stopped instead of enabled/disabled