### PR TITLE
feat: make MTU configurable in TUI interactive flow

### DIFF
--- a/internal/handlers/tunnel_add.go
+++ b/internal/handlers/tunnel_add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/net2share/dnstm/internal/actions"
 	"github.com/net2share/dnstm/internal/certs"
@@ -129,6 +130,34 @@ func addTunnelInteractive(ctx *actions.Context, cfg *config.Config) error {
 		break
 	}
 
+	// Get MTU for DNSTT
+	mtu := 1232
+	if config.TransportType(transportType) == config.TransportDNSTT {
+		for {
+			mtuStr, confirmed, mtuErr := tui.RunInput(tui.InputConfig{
+				Title:       "MTU",
+				Description: "DNS packet MTU (512-1400)",
+				Value:       "1232",
+			})
+			if mtuErr != nil {
+				return mtuErr
+			}
+			if !confirmed {
+				return nil
+			}
+			if mtuStr == "" {
+				mtuStr = "1232"
+			}
+			parsed, parseErr := strconv.Atoi(mtuStr)
+			if parseErr != nil || parsed < 512 || parsed > 1400 {
+				ctx.Output.Error("MTU must be a number between 512 and 1400")
+				continue
+			}
+			mtu = parsed
+			break
+		}
+	}
+
 	// Build tunnel config
 	tunnelCfg := &config.TunnelConfig{
 		Tag:       tag,
@@ -139,7 +168,7 @@ func addTunnelInteractive(ctx *actions.Context, cfg *config.Config) error {
 
 	// Transport-specific configuration
 	if tunnelCfg.Transport == config.TransportDNSTT {
-		tunnelCfg.DNSTT = &config.DNSTTConfig{MTU: 1232}
+		tunnelCfg.DNSTT = &config.DNSTTConfig{MTU: mtu}
 	}
 
 	// Allocate port

--- a/internal/handlers/tunnel_status.go
+++ b/internal/handlers/tunnel_status.go
@@ -50,6 +50,11 @@ func HandleTunnelStatus(ctx *actions.Context) error {
 			{Key: "Status", Value: tunnel.StatusString()},
 		},
 	}
+	if tunnelCfg.Transport == config.TransportDNSTT && tunnelCfg.DNSTT != nil {
+		mainSection.Rows = append(mainSection.Rows, actions.InfoRow{
+			Key: "MTU", Value: fmt.Sprintf("%d", tunnelCfg.DNSTT.MTU),
+		})
+	}
 	infoCfg.Sections = append(infoCfg.Sections, mainSection)
 
 	// Show certificate/key info based on transport type

--- a/internal/router/tunnel.go
+++ b/internal/router/tunnel.go
@@ -134,7 +134,7 @@ func (t *Tunnel) StatusString() string {
 
 // GetFormattedInfo returns formatted information about the tunnel.
 func (t *Tunnel) GetFormattedInfo() string {
-	return fmt.Sprintf(`Tag:       %s
+	info := fmt.Sprintf(`Tag:       %s
 Transport: %s
 Backend:   %s
 Domain:    %s
@@ -150,5 +150,9 @@ Status:    %s
 		t.ServiceName,
 		t.StatusString(),
 	)
+	if t.Transport == config.TransportDNSTT && t.Config != nil && t.Config.DNSTT != nil {
+		info += fmt.Sprintf("MTU:       %d\n", t.Config.DNSTT.MTU)
+	}
+	return info
 }
 


### PR DESCRIPTION
## Summary

- Add MTU input prompt (default 1232, range 512-1400) when creating DNSTT tunnels in TUI interactive mode
- Display MTU in tunnel status view (both TUI and CLI output)